### PR TITLE
BLEをFlutterで触る環境を整えてサンプル実装した

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -34,7 +34,7 @@ android {
     defaultConfig {
         // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
         applicationId "com.example.nigirukun"
-        minSdkVersion 16
+        minSdkVersion 19
         targetSdkVersion 27
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName

--- a/lib/datasources/bluetooth/central_manager.dart
+++ b/lib/datasources/bluetooth/central_manager.dart
@@ -8,29 +8,40 @@ import 'package:flutter_blue/flutter_blue.dart';
 class CentralManager {
   /// private variables
   FlutterBlue _flutterBlue = FlutterBlue.instance;
+  BluetoothDevice _device;
+  List<BluetoothService> _services;
   StreamSubscription _scanSubscription;
-  PublishSubject<ScanResult> _subject = PublishSubject<ScanResult>();
+  StreamSubscription<BluetoothDeviceState> _deviceConnection;
+  StreamSubscription<BluetoothDeviceState> _deviceStateSubscription;
+  PublishSubject<ScanResult> _scanSubject = PublishSubject<ScanResult>();
+  PublishSubject<BluetoothDeviceState> _deviceStateSubject = PublishSubject<BluetoothDeviceState>();
 
   /// const value
   static const String _NIGIRU_KUN_SERVICE =
       "1db31f9a-9137-44da-9458-a4e642211773";
 
-  /// Rx stream data
-  /// stream scanResult can subscribe when discovered NIGIRUKUN device
+  /// connected device. if it's not connected, device will return null
+  BluetoothDevice get device => _device;
+
+  /// scan result data
+  /// rx stream scanResult can subscribe when discovered NIGIRUKUN device
   Observable<ScanResult> get scannedDevice =>
-      _subject.stream
+      _scanSubject.stream
           .where((scanResult) => scanResult.advertisementData.connectable)
           .where((scanResult) => scanResult.advertisementData.serviceUuids
             .where((item) => item == _NIGIRU_KUN_SERVICE).length == 1
           )
           .distinct(([a, b]) => a.device.id.id == b.device.id.id);
 
+  /// connected bluetooth device state
+  /// rx stream BluetoothDeviceState can subscribe when changed connection state
+  Observable<BluetoothDeviceState> get deviceState => _deviceStateSubject.stream;
 
   /// scan devices which has unique NIGIRUKUN service uuid
   /// - parameter timeout: [default 10 seconds] duration of scanning
   startDeviceScan([int timeout = 10]) {
-    if (_subject.isClosed) {
-      _subject = PublishSubject<ScanResult>();
+    if (_scanSubject.isClosed) {
+      _scanSubject = PublishSubject<ScanResult>();
     }
     _scanSubscription = _flutterBlue
         .scan(
@@ -42,14 +53,47 @@ class CentralManager {
       print(
           'manufacturerData: ${scanResult.advertisementData.manufacturerData}');
       print('serviceData: ${scanResult.advertisementData.serviceData}');
-      _subject.add(scanResult);
-    }, onDone: _stopScan);
+      _scanSubject.add(scanResult);
+    }, onDone: stopScan);
   }
 
   /// stop scanning
-  _stopScan() {
+  stopScan() {
     _scanSubscription?.cancel();
     _scanSubscription = null;
-    _subject.close();
+    _scanSubject.close();
+  }
+
+  /// connect device
+  /// - parameter device: try to connect device instance
+  connect(BluetoothDevice device) {
+    _device = device;
+
+    // Connect to device
+    _deviceConnection = _flutterBlue.connect(device).listen(null, onDone: disconnect);
+
+    // Update the connection state
+    device.state.then((s){
+      _deviceStateSubject.add(s);
+    });
+
+    //
+    _deviceStateSubscription = device.onStateChanged().listen((s){
+      if (s == BluetoothDeviceState.connected) {
+        device.discoverServices().then((s){
+          _services = s;
+        });
+      }
+    });
+  }
+
+  /// disconnect device
+  disconnect() {
+    _deviceConnection?.cancel();
+    _deviceStateSubscription = null;
+    _deviceStateSubject.close();
+    _deviceConnection?.cancel();
+    _deviceConnection = null;
+    _device = null;
   }
 }

--- a/lib/datasources/bluetooth/central_manager.dart
+++ b/lib/datasources/bluetooth/central_manager.dart
@@ -6,17 +6,24 @@ import 'package:rxdart/rxdart.dart';
 import 'package:flutter_blue/flutter_blue.dart';
 
 class CentralManager {
+  /// private variables
   FlutterBlue _flutterBlue = FlutterBlue.instance;
   StreamSubscription _scanSubscription;
   PublishSubject<ScanResult> _subject = PublishSubject<ScanResult>();
+
+  /// const value
   static const String _NIGIRU_KUN_SERVICE =
       "1db31f9a-9137-44da-9458-a4e642211773";
 
+  /// Rx stream data
+  /// stream scanResult can subscribe when discovered NIGIRUKUN device
   Observable<ScanResult> get scannedDevice =>
       _subject.stream.where((scanResult) =>
           scanResult.advertisementData.serviceUuids.first ==
           _NIGIRU_KUN_SERVICE);
 
+  /// scan devices which has unique NIGIRUKUN service uuid
+  /// - parameter timeout: [default 10 seconds] duration of scanning
   startDeviceScan([int timeout = 10]) {
     if (_subject.isClosed) {
       _subject = PublishSubject<ScanResult>();
@@ -35,6 +42,7 @@ class CentralManager {
     }, onDone: _stopScan);
   }
 
+  /// stop scanning
   _stopScan() {
     _scanSubscription?.cancel();
     _scanSubscription = null;

--- a/lib/datasources/bluetooth/central_manager.dart
+++ b/lib/datasources/bluetooth/central_manager.dart
@@ -1,0 +1,27 @@
+import 'dart:async';
+
+import 'package:flutter_blue/flutter_blue.dart';
+
+class CentralManager {
+  FlutterBlue _flutterBlue = FlutterBlue.instance;
+  StreamSubscription _scanSubscription;
+  Map<DeviceIdentifier, ScanResult> scanResults = new Map();
+  static const String _NIGIRU_KUN_SERVICE =
+      "0000180F-0000-1000-8000-00805F9B34FB";
+
+  startScan() {
+    _scanSubscription = _flutterBlue.scan(
+        timeout: const Duration(seconds: 30),
+        /*withServices: [new Guid(_NIGIRU_KUN_SERVICE)]*/).listen((scanResult) {
+      print('localName: ${scanResult.advertisementData.localName}');
+      print('manufacturerData: ${scanResult.advertisementData.manufacturerData}');
+      print('serviceData: ${scanResult.advertisementData.serviceData}');
+      scanResults[scanResult.device.id] = scanResult;
+    }, onDone: _stopScan);
+  }
+
+  _stopScan() {
+    _scanSubscription?.cancel();
+    _scanSubscription = null;
+  }
+}

--- a/lib/datasources/bluetooth/central_manager.dart
+++ b/lib/datasources/bluetooth/central_manager.dart
@@ -1,27 +1,43 @@
 import 'dart:async';
+import 'dart:core';
+import 'package:rxdart/subjects.dart';
+import 'package:rxdart/rxdart.dart';
 
 import 'package:flutter_blue/flutter_blue.dart';
 
 class CentralManager {
   FlutterBlue _flutterBlue = FlutterBlue.instance;
   StreamSubscription _scanSubscription;
-  Map<DeviceIdentifier, ScanResult> scanResults = new Map();
+  PublishSubject<ScanResult> _subject = PublishSubject<ScanResult>();
   static const String _NIGIRU_KUN_SERVICE =
-      "0000180F-0000-1000-8000-00805F9B34FB";
+      "1db31f9a-9137-44da-9458-a4e642211773";
 
-  startScan() {
-    _scanSubscription = _flutterBlue.scan(
-        timeout: const Duration(seconds: 30),
-        /*withServices: [new Guid(_NIGIRU_KUN_SERVICE)]*/).listen((scanResult) {
+  Observable<ScanResult> get scannedDevice =>
+      _subject.stream.where((scanResult) =>
+          scanResult.advertisementData.serviceUuids.first ==
+          _NIGIRU_KUN_SERVICE);
+
+  startDeviceScan([int timeout = 10]) {
+    if (_subject.isClosed) {
+      _subject = PublishSubject<ScanResult>();
+    }
+    _scanSubscription = _flutterBlue
+        .scan(
+      timeout: Duration(seconds: timeout),
+    )
+        .listen((scanResult) {
       print('localName: ${scanResult.advertisementData.localName}');
-      print('manufacturerData: ${scanResult.advertisementData.manufacturerData}');
+      print('connectable: ${scanResult.advertisementData.connectable}');
+      print(
+          'manufacturerData: ${scanResult.advertisementData.manufacturerData}');
       print('serviceData: ${scanResult.advertisementData.serviceData}');
-      scanResults[scanResult.device.id] = scanResult;
+      _subject.add(scanResult);
     }, onDone: _stopScan);
   }
 
   _stopScan() {
     _scanSubscription?.cancel();
     _scanSubscription = null;
+    _subject.close();
   }
 }

--- a/lib/datasources/bluetooth/central_manager.dart
+++ b/lib/datasources/bluetooth/central_manager.dart
@@ -18,9 +18,13 @@ class CentralManager {
   /// Rx stream data
   /// stream scanResult can subscribe when discovered NIGIRUKUN device
   Observable<ScanResult> get scannedDevice =>
-      _subject.stream.where((scanResult) =>
-          scanResult.advertisementData.serviceUuids.first ==
-          _NIGIRU_KUN_SERVICE);
+      _subject.stream
+          .where((scanResult) => scanResult.advertisementData.connectable)
+          .where((scanResult) => scanResult.advertisementData.serviceUuids
+            .where((item) => item == _NIGIRU_KUN_SERVICE).length == 1
+          )
+          .distinct(([a, b]) => a.device.id.id == b.device.id.id);
+
 
   /// scan devices which has unique NIGIRUKUN service uuid
   /// - parameter timeout: [default 10 seconds] duration of scanning

--- a/lib/datasources/bluetooth/central_manager.dart
+++ b/lib/datasources/bluetooth/central_manager.dart
@@ -77,7 +77,7 @@ class CentralManager {
       _deviceStateSubject.add(s);
     });
 
-    //
+    // Add service
     _deviceStateSubscription = device.onStateChanged().listen((s){
       if (s == BluetoothDeviceState.connected) {
         device.discoverServices().then((s){

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -24,6 +24,8 @@ dependencies:
 
   flutter_blue: ^0.4.1
 
+  rxdart: ^0.19.0
+
 dev_dependencies:
   flutter_test:
     sdk: flutter

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -22,6 +22,8 @@ dependencies:
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^0.1.2
 
+  flutter_blue: ^0.4.1
+
 dev_dependencies:
   flutter_test:
     sdk: flutter


### PR DESCRIPTION
## Why
- BLEをさわりたい．

## What
- PlugInとして，flutter_blue，rx_dartをいれました．
- AndroidにおいてAPI Versionが低いとそもそもBLEの規格がアなので，minSdkVersersionを変えました．
- centralの実装してscan，connectをじっそうしました．
    - scan時はにぎるくん固有のサービスだけを拾うようにしました．
- これらはいずれmapperによっていい感じのentityになり，最後はrepositoryに流れます．

### References
- [flutter_blueのdocument](https://pub.dartlang.org/documentation/flutter_blue/latest/)
- [rx_dartのdocument](https://pub.dartlang.org/documentation/rxdart/latest/)