### PR TITLE
countを正しく流せるようにした．

### DIFF
--- a/lib/datasources/databases/model/counts.dart
+++ b/lib/datasources/databases/model/counts.dart
@@ -50,17 +50,19 @@ create table $tableCount (
   }
 
 
-  // TODO fix me
-  Future<Count> getCount(DateTime from, DateTime to) async {
+  Future<List<Count>> getCount(DateTime from, DateTime to) async {
     String qFrom = from?.toString() ?? "0000-01-01 00:00:00.000000";
     String qTo = to?.toString() ?? DateTime.now().toString();
-    print("run query ================== >");
-    List<Map> maps = await db.rawQuery("SELECT * FROM ?",[tableCount]);
-    // between指定ができない．
-    // 結果をListとして撮れない
-    print(maps);
-    print("end query ================== >${maps?.length ?? 0}");
-    return Count.fromMap(maps.first);
+    List<Map> maps = await db.query(tableCount,
+      columns: [countId, countWeight, countTime],
+      where: '$countTime >= ? AND $countTime <= ?',
+      whereArgs: [qFrom, qTo]
+    );
+    List<Count> result = List<Count>();
+    maps.forEach((map) {
+      result.add(Count.fromMap(map));
+    });
+    return result;
   }
 
   Future close() async => db.close();

--- a/lib/entities/nigirukun_sensor_data.dart
+++ b/lib/entities/nigirukun_sensor_data.dart
@@ -16,7 +16,7 @@ class NigirukunForceensorData {
   List<int> force;
   DateTime time;
 
-  NigirukunSensorData(List<int> force, DateTime time){
+  NigirukunForceensorData(List<int> force, DateTime time){
     this.force = force;
     this.time = time ?? DateTime.now();
   }

--- a/lib/repositorys/sensor_repository.dart
+++ b/lib/repositorys/sensor_repository.dart
@@ -43,13 +43,15 @@ class SensorRepositoryImpl implements SensorRepository {
 
   @override
   void getCount(DateTime from, DateTime to) {
-    dbProvider.getCount(null,null).then((item) {
-      _insertedStream.add([NigirukunCountSensorData(1, DateTime.parse(item.time))].toList());
+    Observable.fromFuture(dbProvider.getCount(null, null))
+      .listen((item) {
+        List<NigirukunCountSensorData> data = item.map((e) {
+          return NigirukunCountSensorData(1, DateTime.parse(e.time));
+        }).toList();
+      _insertedStream.add(data);
     });
   }
 
-  //TODO fix me
-  // databaseのgetCountがバグっているため．こっちも付随してバグる
   @override
   Observable<List<NigirukunCountSensorData>> get observeCount => _insertedStream.stream;
 


### PR DESCRIPTION
## Why
- between句は多分壊れてるので，普通にwhereでいけた()

## What
- バグつぶし

## Usage
- SensorRepository
    - `getCount`は`from`から`to`の間のcountの回数を引っ張り出してくる．
    - `observeCount`は`getCount`の結果が流れるstream
    - `observeLastinserted`は握られた瞬間に流れてくるstream